### PR TITLE
Fix scons install-core

### DIFF
--- a/src/mongo/db/SConscript
+++ b/src/mongo/db/SConscript
@@ -743,6 +743,7 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 

--- a/src/mongo/db/catalog/SConscript
+++ b/src/mongo/db/catalog/SConscript
@@ -23,6 +23,7 @@ env.Library(
         '$BUILD_DIR/mongo/db/command_generic_argument',
         '$BUILD_DIR/mongo/db/query/collation/collator_interface',
         '$BUILD_DIR/mongo/db/server_parameters',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 
@@ -124,6 +125,8 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/db/common',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 
@@ -134,6 +137,7 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 
@@ -174,6 +178,7 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 
@@ -184,6 +189,7 @@ env.Library(
     ],
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 

--- a/src/mongo/db/commands/SConscript
+++ b/src/mongo/db/commands/SConscript
@@ -84,6 +84,7 @@ env.Library(
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/command_generic_argument',
         '$BUILD_DIR/mongo/db/namespace_string',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 

--- a/src/mongo/db/concurrency/SConscript
+++ b/src/mongo/db/concurrency/SConscript
@@ -26,7 +26,8 @@ env.Library(
         'write_conflict_exception.cpp'
     ],
     LIBDEPS=[
-        '$BUILD_DIR/mongo/db/server_parameters'
+        '$BUILD_DIR/mongo/db/server_parameters',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ],
 )
 

--- a/src/mongo/db/query/datetime/SConscript
+++ b/src/mongo/db/query/datetime/SConscript
@@ -12,7 +12,8 @@ timeZoneEnv.Library(
         'date_time_support.cpp'
     ],
     LIBDEPS=[
-        '$BUILD_DIR/mongo/db/service_context',
+        # '$BUILD_DIR/mongo/db/service_context',
+        '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/third_party/shim_timelib',
     ]
 )
@@ -25,6 +26,7 @@ timeZoneEnv.Library(
     LIBDEPS=[
         'date_time_support',
         '$BUILD_DIR/mongo/db/server_options_core',
+        '$BUILD_DIR/mongo/db/service_context',
         '$BUILD_DIR/third_party/shim_timelib',
     ]
 )

--- a/src/mongo/db/storage/SConscript
+++ b/src/mongo/db/storage/SConscript
@@ -216,6 +216,7 @@ env.Library(
     ],
     LIBDEPS_PRIVATE=[
         '$BUILD_DIR/mongo/db/commands/server_status',
+        '$BUILD_DIR/mongo/idl/idl_parser',
     ]
 )
 

--- a/src/mongo/idl/SConscript
+++ b/src/mongo/idl/SConscript
@@ -11,6 +11,7 @@ env.Library(
     LIBDEPS=[
         '$BUILD_DIR/mongo/base',
         '$BUILD_DIR/mongo/db/command_generic_argument',
+        '$BUILD_DIR/mongo/db/pipeline/document_value',
     ]
 )
 


### PR DESCRIPTION
After PR #10, scons debug install-core failed with many link errors like `verifyRefCountingIfShould` not found.

Before PR #10, scons debug install-core won't compile function calls to `verifyRefCountingIfShould`, according to outputs of objdump. After PR #10, function calls to `verifyRefCountingIfShould` will be compiled. However, those source files haven't linked src/mongo/db/pipeline/value.cpp, which led to link error.

This PR fixes them by altering link dependencies as follows:
libs depend on IDL generated files  <- libidl_parser <- libdocument_value <- value.cpp