### PR TITLE
Fix KVStorageEngine::reconcileCatalogAndIdents crash and metadata.idxIdent value wrong

### DIFF
--- a/src/mongo/db/storage/kv/kv_catalog.h
+++ b/src/mongo/db/storage/kv/kv_catalog.h
@@ -98,6 +98,8 @@ public:
     std::vector<std::string> getAllIdentsForDB(StringData db) const;
     std::vector<std::string> getAllIdents(OperationContext* opCtx) const;
 
+    bool isSystemDataIdent(StringData ident) const;
+
     bool isUserDataIdent(StringData ident) const;
 
     bool isCollectionIdent(StringData ident) const;

--- a/src/mongo/db/storage/kv/kv_storage_engine.cpp
+++ b/src/mongo/db/storage/kv/kv_storage_engine.cpp
@@ -365,9 +365,14 @@ KVStorageEngine::reconcileCatalogAndIdents(OperationContext* opCtx) {
             continue;
         }
 
-        if (!_catalog->isUserDataIdent(it)) {
+        if (_catalog->isSystemDataIdent(it))
+        {
             continue;
         }
+
+        // if (!_catalog->isUserDataIdent(it)) {
+        //     continue;
+        // }
 
         // In repair context, any orphaned collection idents from the engine should already be
         // recovered in the catalog in loadCatalog().


### PR DESCRIPTION
This PR with PR monographdb/monographdb_engine_for_mongodb#44 fix issues monographdb/monographdb_engine_for_mongodb#41 and monographdb/monographdb_engine_for_mongodb#43