### PR TITLE
RecordId::repr() return 0.

### DIFF
--- a/src/mongo/db/record_id.h
+++ b/src/mongo/db/record_id.h
@@ -227,11 +227,10 @@ public:
 
     // repr() now just for Format::kLong
     int64_t repr() const {
-        if (_format == Format::kNull) {
-            return 0;
-        }
-        invariant(isLong());
-        return _getLongNoCheck();
+        // In the monograph engine, the RecordId is equivalent to the "_id" field and is stored as a
+        // string. Therefore, the repr() function is meaningless.
+        // Returning 0 ensures compatibility with the existing API.
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Fix https://github.com/monographdb/monographdb_engine_for_mongodb/issues/98 .

In the official MongoDB implementation, the RecordId is allocated by the embedded WiredTiger storage engine and is stored as an `int64_t` data type.
However, in the monograph storage engine, the `RecordId` is equivalent to the "_id" field in a JSON document and is stored as a `string`. Therefore, the `repr()` function is meaningless. 
Considering the typical user experience, acquiring an internal unique identifier designed for the storage engine is a rare occurrence. Returning 0 ensures compatibility with the existing API.