### PR TITLE
MonographLockerNoop::getClientState return fake data.

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -8,7 +8,7 @@ If:
     ]
 CompileFlags:
   CompilationDatabase: ./
-  Add: [-Isrc/third_party/asio-master/asio/include, -Wall]
+  Add: [-Isrc/third_party/asio-master/asio/include, -Wall, -I/usr/lib/gcc/x86_64-linux-gnu/13/include]
 Diagnostics:
   Suppress: builtin_definition
   UnusedIncludes: Strict
@@ -36,7 +36,7 @@ If:
     ]
 CompileFlags:
   CompilationDatabase: src/mongo/db/modules/monograph/build
-  Add: [-Wall]
+  Add: [-Wall, -I/usr/lib/gcc/x86_64-linux-gnu/13/include]
 Diagnostics:
   Suppress: builtin_definition
   UnusedIncludes: Strict

--- a/src/mongo/db/concurrency/monograph_locker_noop.h
+++ b/src/mongo/db/concurrency/monograph_locker_noop.h
@@ -53,7 +53,8 @@ public:
     }
 
     ClientState getClientState() const override {
-        // MONGO_UNREACHABLE;
+        // Return fake data
+        return ClientState::kInactive;
     }
 
     LockerId getId() const override {
@@ -268,10 +269,14 @@ public:
         return true;
     }
 
+private:
     LockMode _lockMode{LockMode::MODE_NONE};
     // Delays release of exclusive/intent-exclusive locked resources until the write unit of
     // work completes. Value of 0 means we are not inside a write unit of work.
     int _wuowNestingLevel{0};
+
+    // Indicates whether the client is active reader/writer or is queued.
+    AtomicWord<ClientState> _clientState{kInactive};
 };
 
 }  // namespace mongo


### PR DESCRIPTION
Currently, we do not support [client state statistics](https://www.mongodb.com/docs/manual/reference/command/serverStatus/#mongodb-serverstatus-serverstatus.globalLock.activeClients), as our system employs a proprietary concurrency control algorithm that operates independently of the official MongoDB implementation. As a result, we simply return mock data in such cases.

