### PR TITLE
Check and correct user defined id index specification before create collection.

### DIFF
--- a/src/mongo/db/catalog/database_impl.h
+++ b/src/mongo/db/catalog/database_impl.h
@@ -259,6 +259,7 @@ private:
     Collection* _createCollectionHandler(OperationContext* opCtx,
                                          const NamespaceString& nss,
                                          bool createIdIndex,
+                                         const BSONObj& idIndexSpec = BSONObj{},
                                          bool forView = false);
 
     /**

--- a/src/mongo/db/storage/bson_collection_catalog_entry.h
+++ b/src/mongo/db/storage/bson_collection_catalog_entry.h
@@ -51,7 +51,7 @@ public:
     virtual ~BSONCollectionCatalogEntry() {}
 
     // virtual CollectionOptions getCollectionOptions(OperationContext* opCtx) const = 0;
-     MetaData getMetaData(OperationContext* opCtx) const override;
+    MetaData getMetaData(OperationContext* opCtx) const override;
 
     virtual int getTotalIndexCount(OperationContext* opCtx) const;
 
@@ -87,8 +87,6 @@ public:
     // }
 
     // ------ for implementors
-
-
 
 protected:
     virtual MetaData _getMetaData(OperationContext* opCtx) const = 0;

--- a/src/mongo/transport/service_executor_coroutine.cpp
+++ b/src/mongo/transport/service_executor_coroutine.cpp
@@ -151,8 +151,8 @@ Status ServiceExecutorCoroutine::_startWorker(int16_t groupId) {
         }
         localThreadId = threadGroupId;
 
-        // std::string threadName("thread_group_" + std::to_string(threadGroupId));
-        std::string threadName("thread_group");
+        std::string threadName("thread_group_" + std::to_string(threadGroupId));
+        // std::string threadName("thread_group");
         StringData threadNameSD(threadName);
         setThreadName(threadNameSD);
 


### PR DESCRIPTION
MongoDB processes the `createCollection` command in two distinct steps:
1. creates the collection.
2. creates the _id index.

In contrast, Monograph handles the `createCollection` command in a single step, consolidating the process into the initial "create the collection" phase.
However, during the creation of the _id index, MongoDB performs several validation checks that may alter the original index specification. To ensure consistency and avoid potential conflicts, it is advisable to perform these checks before the collection creation stage. For example, https://github.com/monographdb/monographdb_engine_for_mongodb/issues/80 input a user defined id Index named "a_1".

The check code is largely derived from `src/mongo/db/catalog/index_catalog_impl.cpp`, with some modifications made to accommodate the current context where a `Collection` object is not yet available.