### PR TITLE
Verify the existence of the database in the storage engine prior to invoking the openDB.

### DIFF
--- a/src/mongo/db/catalog/database_holder_impl.cpp
+++ b/src/mongo/db/catalog/database_holder_impl.cpp
@@ -106,6 +106,12 @@ Database* DatabaseHolderImpl::get(OperationContext* opCtx, StringData ns) {
         return iter->second.get();
     }
 
+    // https://www.mongodb.com/docs/manual/core/databases-and-collections/#create-a-database
+    // MongoDB does not offer an explicit "createDatabase" command or API. Instead, if a database
+    // does not exist, MongoDB automatically creates it when data is first stored in that database.
+    // In MongoDB, the existence of a database is typically determined by the "Database *" in C++.
+    // However, in Monograph, we verify the database's existence through the storage engine API,
+    // which serves as our source of truth.
     bool existInStorageEngine =
         opCtx->getServiceContext()->getStorageEngine()->databaseExists(ns.toStringView());
     if (existInStorageEngine) {

--- a/src/mongo/db/catalog/drop_database.cpp
+++ b/src/mongo/db/catalog/drop_database.cpp
@@ -154,7 +154,7 @@ Status dropDatabase(OperationContext* opCtx, const std::string& dbName) {
 
         log() << "dropDatabase " << dbName << " - dropping " << numCollectionsToDrop
               << " collections";
-        for (auto nss : collectionsToDrop) {
+        for (const auto& nss : collectionsToDrop) {
             log() << "dropDatabase " << dbName << " - dropping collection: " << nss;
             if (!opCtx->writesAreReplicated()) {
                 // Dropping a database on a primary replicates individual collection drops

--- a/src/mongo/db/storage/kv/kv_engine.h
+++ b/src/mongo/db/storage/kv/kv_engine.h
@@ -65,9 +65,22 @@ public:
     }
     // ---------
 
-    virtual void listDatabases(std::vector<std::string>& out) const {}
-    virtual void listCollections(std::string_view dbName, std::vector<std::string>& out) const {}
-    virtual void listCollections(std::string_view dbName, std::set<std::string>& out) const {}
+    virtual void listDatabases(std::vector<std::string>& out) const {
+        MONGO_UNREACHABLE;
+    }
+
+    virtual bool databaseExists(std::string_view dbName) const {
+        MONGO_UNREACHABLE;
+        return false;
+    }
+
+    virtual void listCollections(std::string_view dbName, std::vector<std::string>& out) const {
+        MONGO_UNREACHABLE;
+    }
+
+    virtual void listCollections(std::string_view dbName, std::set<std::string>& out) const {
+        MONGO_UNREACHABLE;
+    }
     /**
      * Having multiple out for the same ns is a rules violation; Calling on a non-created ident is
      * invalid and may crash.

--- a/src/mongo/db/storage/kv/kv_storage_engine.cpp
+++ b/src/mongo/db/storage/kv/kv_storage_engine.cpp
@@ -365,8 +365,7 @@ KVStorageEngine::reconcileCatalogAndIdents(OperationContext* opCtx) {
             continue;
         }
 
-        if (_catalog->isSystemDataIdent(it))
-        {
+        if (_catalog->isSystemDataIdent(it)) {
             continue;
         }
 
@@ -519,6 +518,10 @@ void KVStorageEngine::listDatabases(std::vector<std::string>* out) const {
     //         continue;
     //     out->push_back(it->first);
     // }
+}
+
+bool KVStorageEngine::databaseExists(std::string_view dbName) const {
+    return _engine->databaseExists(dbName);
 }
 
 void KVStorageEngine::listCollections(std::string_view dbName,

--- a/src/mongo/db/storage/kv/kv_storage_engine.h
+++ b/src/mongo/db/storage/kv/kv_storage_engine.h
@@ -92,6 +92,7 @@ public:
                                            bool isForWrite) override;
 
     void listDatabases(std::vector<std::string>* out) const override;
+    bool databaseExists(std::string_view dbName) const override;
     void listCollections(std::string_view dbName, std::vector<std::string>* out) const override;
     void listCollections(std::string_view dbName, std::set<std::string>& out) const override;
     KVDatabaseCatalogEntryBase* getDatabaseCatalogEntry(OperationContext* opCtx,

--- a/src/mongo/db/storage/storage_engine.h
+++ b/src/mongo/db/storage/storage_engine.h
@@ -176,8 +176,16 @@ public:
      * XXX: why doesn't this take OpCtx?
      */
     virtual void listDatabases(std::vector<std::string>* out) const = 0;
-    virtual void listCollections(std::string_view dbName, std::vector<std::string>* out) const {};
-    virtual void listCollections(std::string_view dbName, std::set<std::string>& out) const {};
+    virtual bool databaseExists(std::string_view dbName) const {
+        MONGO_UNREACHABLE;
+        return false;
+    }
+    virtual void listCollections(std::string_view dbName, std::vector<std::string>* out) const {
+        MONGO_UNREACHABLE;
+    }
+    virtual void listCollections(std::string_view dbName, std::set<std::string>& out) const {
+        MONGO_UNREACHABLE;
+    }
     /**
      * Return the DatabaseCatalogEntry that describes the database indicated by 'db'.
      *

--- a/src/mongo/util/unordered_fast_key_table.h
+++ b/src/mongo/util/unordered_fast_key_table.h
@@ -32,6 +32,7 @@
 #include <iterator>
 #include <memory>
 #include <type_traits>
+#include <utility>
 
 #include "mongo/base/disallow_copying.h"
 #include "mongo/util/assert_util.h"
@@ -263,7 +264,7 @@ public:
     }
 
     template <typename AreaPtr,
-              typename reference = decltype(AreaPtr()->begin()->getData()),
+              typename reference = decltype(std::declval<AreaPtr>()->begin()->getData()),
               typename pointer = typename std::add_pointer<reference>::type>
     class iterator_impl
         : public std::
@@ -428,6 +429,6 @@ private:
     size_t _size = 0;
     Area _area;
 };
-}
+}  // namespace mongo
 
 #include "mongo/util/unordered_fast_key_table_internal.h"


### PR DESCRIPTION
We should verify the existence of the database through the storage engine API before creating a `Database` object, thereby avoiding unnecessary operations on a non-existent database.

Fix https://github.com/monographdb/monographdb_engine_for_mongodb/issues/82 and https://github.com/monographdb/monographdb_engine_for_mongodb/issues/85.

For the relevant modifications in Monograph, please refer to the following PR: https://github.com/monographdb/monographdb_engine_for_mongodb/pull/103