### PR TITLE
Fix destruct ObjectPool<CanonicalQuery>

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -7,7 +7,7 @@ If:
       src/mongo/db/modules/monograph/mono_metrics/.*,
     ]
 CompileFlags:
-  CompilationDatabase: ./
+  CompilationDatabase: ./build
   Add: [-Isrc/third_party/asio-master/asio/include, -Wall, -I/usr/lib/gcc/x86_64-linux-gnu/13/include]
 Diagnostics:
   Suppress: builtin_definition

--- a/src/mongo/db/query/canonical_query.cpp
+++ b/src/mongo/db/query/canonical_query.cpp
@@ -491,4 +491,9 @@ std::string CanonicalQuery::toStringShort() const {
     return ss;
 }
 
+template <>
+void deinit(CanonicalQuery* ptr) {
+    // Release 'QueryRequest::UPtr _qr' and return it to ObjectPool<QueryRequest>.
+    ptr->reset();
+}
 }  // namespace mongo

--- a/src/mongo/db/query/canonical_query.h
+++ b/src/mongo/db/query/canonical_query.h
@@ -195,6 +195,12 @@ private:
     std::unique_ptr<CollatorInterface> _collator;
 
     bool _canHaveNoopMatchNodes = false;
+
+    template <typename T>
+    friend void deinit(T* ptr);
 };
+
+template <>
+void deinit(CanonicalQuery* ptr);
 
 }  // namespace mongo


### PR DESCRIPTION
CanonicalQuery owns QueryRequest::Uptr. When `ObjectPool<CanonicalQuery>` is being destructed, CanonicalQuery destructs QueryRequest::Uptr, which will be returned to `ObjectPool<QueryRequest>`. However, `ObjectPool<QueryRequest>` might have been destructed at that time due to threads stopping.

Reset CanonicalQuery before returning it to `ObjectPool<CanonicalQuery>`, so that pooled CanonicalQuery owns a null  QueryRequest::Uptr.