### PR TITLE
Support save and restore lock state. Skip redundant code in Mongo as index building is already handled by txservice.

### DIFF
--- a/src/mongo/db/catalog/index_create_impl.cpp
+++ b/src/mongo/db/catalog/index_create_impl.cpp
@@ -62,9 +62,9 @@
 
 namespace mongo {
 
-using std::unique_ptr;
-using std::string;
 using std::endl;
+using std::string;
+using std::unique_ptr;
 
 MONGO_FAIL_POINT_DEFINE(crashAfterStartingIndexBuild);
 MONGO_FAIL_POINT_DEFINE(hangAfterStartingIndexBuild);
@@ -338,6 +338,9 @@ void failPointHangDuringBuild(FailPoint* fp, StringData where, const BSONObj& do
 }
 
 Status MultiIndexBlockImpl::insertAllDocumentsInCollection(std::set<RecordId>* dupsOut) {
+    // This is currently a no-op, as index building is handled by Monograph.
+    return Status::OK();
+
     invariant(!_opCtx->lockState()->inAWriteUnitOfWork());
 
     // Refrain from persisting any multikey updates as a result from building the index. Instead,


### PR DESCRIPTION
This PR fixes `jstests/core/auth_copydb.js` in https://github.com/monographdb/monographdb_engine_for_mongodb/issues/70. The `copyDatabase` operation calls `saveLockStateAndUnlock` and `restoreLockState`, and these functions have been implemented to properly restore the lock state.

Additionally, after users are created in this test, MongoDB attempts to create an index for the "user" field on the `admin.system.users` collection during the next startup. However, the index creation is already handled by `txservice` when MongoDB updates its table schema to include the index specification. Therefore, the index build code in MongoDB—which scans the base table and inserts index entries—should be skipped.

For more context, refer to the discussion in https://github.com/monographdb/monographdb_engine_for_mongodb/pull/111#discussion_r1918158867, which addresses an unusual call sequence to the storage engine API caused by this behavior.